### PR TITLE
Added github action for building on different platforms and python versions

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,0 +1,40 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - os: ubuntu-22.04
+            python-version: "3.6"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install -r examples/requirements.txt
+      - name: Install tmu
+        run: |
+          pip install -e .
+      - name: Test with pytest
+        run: pytest test --doctest-modules --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,0 +1,2 @@
+scikit-learn
+tensorflow

--- a/test/test_imports.py
+++ b/test/test_imports.py
@@ -1,0 +1,11 @@
+
+
+
+def test_import_clause_bank():
+    import tmu._cb
+
+def test_import_tools():
+    import tmu._tools
+
+def test_import_weight_bank():
+    import tmu._wb

--- a/tmu/datasets.py
+++ b/tmu/datasets.py
@@ -1,0 +1,43 @@
+import abc
+from typing import Dict
+
+import numpy as np
+
+
+class TMUDataset:
+
+    def __init__(self):
+        pass
+
+    @abc.abstractmethod
+    def booleanizer(self, name, dataset):
+        raise NotImplementedError("You should override def threshold()")
+
+    @abc.abstractmethod
+    def retrieve_dataset(self) -> Dict[str, np.ndarray]:
+        raise NotImplementedError("You should override def retrieve_dataset()")
+
+    def get(self):
+        return {k: self.booleanizer(k, v) for k, v in self.retrieve_dataset().items()}
+
+    def get_list(self):
+        return list(self.get().values())
+
+
+class MNIST(TMUDataset):
+    def retrieve_dataset(self) -> Dict[str, np.ndarray]:
+        from keras.datasets import mnist
+        (X_train, Y_train), (X_test, Y_test) = mnist.load_data()
+        return dict(
+            x_train=X_train,
+            y_train=Y_train,
+            x_test=X_test,
+            y_test=Y_test
+        )
+
+    def booleanizer(self, name, dataset):
+        if name.startswith("y"):
+            return dataset
+
+        return np.where(dataset.reshape((dataset.shape[0], 28*28)) > 75, 1, 0)
+


### PR DESCRIPTION
The following pull request adds github action for building tmu on different systems (ubuntu, mac, windows)
with version 3.6 up to 3.10.

We can further updates this to push to pypi automatically later, but currently it provides a measure for compatability on different platforms.

A generic dataset API also follows (datasets.py), which currently includes MNIST as an example.