### PR TITLE
Fixing the autoencoder model

### DIFF
--- a/tmu/models/autoencoder/autoencoder.py
+++ b/tmu/models/autoencoder/autoencoder.py
@@ -118,7 +118,7 @@ class TMAutoEncoder(TMBaseModel, SingleClauseBankMixin, MultiWeightBankMixin):
             clause_active,
             literal_active
     ):
-        all_literal_active = (np.zeros(self.clause_bank.number_of_ta_chunks, dtype=np.uint32) | ~0).astype(np.uint32)
+        all_literal_active = np.full(self.clause_bank.number_of_ta_chunks, np.iinfo(np.uint32).max, dtype=np.uint32)
         clause_outputs = self.clause_bank.calculate_clause_outputs_update(all_literal_active, encoded_X, 0)
 
         class_sum = np.dot(clause_active * self.weight_banks[target_output].get_weights(), clause_outputs).astype(

--- a/tmu/models/base.py
+++ b/tmu/models/base.py
@@ -144,7 +144,10 @@ class TMBaseModel:
         self.feedback_rate_excluded_literals = feedback_rate_excluded_literals
         self.literal_insertion_state = literal_insertion_state
         self.squared_weight_update_p = squared_weight_update_p
-
+        
+        self.X_train = np.zeros(0, dtype=np.uint32)
+        self.X_test = np.zeros(0, dtype=np.uint32)
+        
     def clause_co_occurrence(self, X, percentage=False):
         clause_outputs = csr_matrix(self.transform(X))
         if percentage:


### PR DESCRIPTION
Refactor the autoencoder to use np.full instead of ORing with "~0" and fix the initializing of the X_train/X_test in base.py.