### PR TITLE
Update pyproject.toml to remove -mrdrand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ version = {attr = "tmu.__version__"}
 [tool.cffi_builder]
 module_name = "tmu.tmulib"
 flags = [
-    "-O3", "-mrdrnd"
+    "-O3"
 ]
 sources = [
     "tmu/lib/src/ClauseBank.c",


### PR DESCRIPTION
Support for Intel random seed generator was added  (57f138a5de2dafe52d31fed3f40e2d51b3d036c3), along with compiler flag '-mdrand'.

Support for Intel random seed was then later removed, but the compiler flag in pyproject.toml was not (0813235d0b13d2c12e39011c733d419551b72c5a).

Removing the compiler flag allows it to build on compilers without compiler support for rdrand, e.g. Apple silicon ARM compilers.